### PR TITLE
Bumped the version of the auth sdk.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-ios",
       "state" : {
-        "branch" : "0.2.1",
-        "revision" : "ab89a0b034931d1bb1e37637899b831d438488c3"
+        "revision" : "ef727557ea600f8096adde5e66ca2f7b141c99f7",
+        "version" : "0.3.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "b6380f683b31072d77b601c88674461c11bcad5a",
-        "version" : "0.30.0"
+        "revision" : "7b42e0343f28b3451aab20840dc670abd12790bd",
+        "version" : "0.36.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "branch" : "0.46.0",
-        "revision" : "3c20e0be8c8246de8b8e04372404ef1f90be71b6"
+        "revision" : "4c084c0e616a660014479ea2e60e7a9533a52a05",
+        "version" : "1.0.17"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "b2322a067f85c230f17c80be8a67dd543454b081",
-        "version" : "0.51.0"
+        "revision" : "274b526e1b329469043a950888ecbd44ed25dfc5",
+        "version" : "0.78.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-ios", branch: "0.2.2")
+        .package(url: "https://github.com/aws-geospatial/amazon-location-mobile-auth-sdk-ios", from: "0.3.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
*Description of changes:*

Bumped up the version of the dependent Auth SDK to the latest (0.3.1). This should resolve issues with package installations as it no longer depends on a branch of a dependency. It also brings the dependent AWS SDK up to version 1.0.17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
